### PR TITLE
Bug transición erronea reparado

### DIFF
--- a/Assets/Scenes/Escena con modelos.unity
+++ b/Assets/Scenes/Escena con modelos.unity
@@ -2745,7 +2745,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   condicion: 100
-  estado: 0
+  estado: 1
   estaDanado: 0
   velocidadReparacion: 1.5
   velocidadDeterioro: 1

--- a/Assets/Scripts/Jugador.cs
+++ b/Assets/Scripts/Jugador.cs
@@ -95,6 +95,7 @@ public class Jugador : MonoBehaviour
                 animator.SetTrigger("trigger_reparadoFinalizado");
                 martillo.SetActive(false);
                 movimientoJugador.enabled = true;
+                zonaReparacionActual= null;
                 break;
             default:
                 break;


### PR DESCRIPTION
-El bug que provocaba que el trigger reparadoFinalizado se quedara encasquillado provocando la transición erronea fue resuelto.